### PR TITLE
Add empty serviceName

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
+  serviceName: ""
   replicas: {{ .Values.replicaCount }}
   updateStrategy:
     type: {{ .Values.statefulset.updateStrategy }}


### PR DESCRIPTION
This would throw errors for us without a `serviceName` field, as described [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#statefulset-v1beta1-apps)

cc: @TylerRichie